### PR TITLE
feat: Add the ability to set env vars for module calls

### DIFF
--- a/src-tsp/main.tsp
+++ b/src-tsp/main.tsp
@@ -125,6 +125,10 @@ model ModuleDefaults {
    * https://blue-build.org/reference/module/#no-cache-optional
    */
   `no-cache`?: boolean = false;
+
+  /** Environment variables to add for the module call.
+   */
+  env?: Record<string>;
 }
 
 @jsonSchema("module-custom-v1.json")


### PR DESCRIPTION
I ran into a moment with setting something up in my recipe and I started to reach for the `containerfile` module to add some `ARG`'s. Then it hit me, why don't we just add that as an optional property on module calls?

```yaml
modules:
- type: script
  env:
    TEST_ENV: 'This is a test'
  snippets:
  - echo "$TEST_ENV"
```