### PR TITLE
feat: Create schema for secret mounts

### DIFF
--- a/src-tsp/main.tsp
+++ b/src-tsp/main.tsp
@@ -129,6 +129,67 @@ model ModuleDefaults {
   /** Environment variables to add for the module call.
    */
   env?: Record<string>;
+
+  /** Secrets to mount for this module call. */
+  secrets?: Array<Secret>;
+}
+
+@oneOf
+union Secret {
+  SecretEnv,
+  SecretFile,
+  SecretExec,
+  SecretSsh,
+}
+
+model SecretEnv {
+  /** A secret pulled from an environment variable. */
+  type: "env";
+
+  /** The name of the environment variable */
+  name: string;
+}
+
+model SecretFile {
+  /** The source file containing the secret.
+   *
+   * NOTE: Relative paths are relative to the root of the repository.
+   */
+  source: string;
+
+  ...SecretExecOutputFile;
+}
+
+model SecretExec {
+  /** A secret pulled from the stdout of a command. */
+  type: "exec";
+
+  /** The command that will be executed. */
+  command: string;
+
+  /** Arguments for the command being executed. */
+  args?: Array<string>;
+
+  /** Defines the output method for the result of the command into the build. */
+  output: SecretExecOutput;
+}
+
+model SecretSsh {
+  /** Mount the SSH socket to use the hosts SSH socket. */
+  type: "ssh";
+}
+
+union SecretExecOutput {
+  SecretEnv,
+  SecretExecOutputFile,
+}
+
+model SecretExecOutputFile {
+  /** A secret pulled from a file on the host system. */
+  type: "file";
+
+  /** The destination path in the build to mount the secret. */
+  destination: string;
 }
 
 @jsonSchema("module-custom-v1.json")


### PR DESCRIPTION
This change would create a schema for mounting secrets for a module call. An example module call would look like:

```yaml
type: script
secrets:
  # Loads an environment variable as a secret
  - type: env
    name: SOME_ENV_VAR

  # Loads the secret to a file in the build
  - type: file
    source: /some/file/somewhere
    destination: /some/location/in/build

  # Executes a command on the host system to retrieve the secret
  - type: exec
    command: some_command
    args:
      - arg1
      - arg2
    output:
      type: file
      destination: /some/other/location
      # Could also do env
      # type: env
      # name: SOME_OTHER_ENV

snippets:
  - echo "$SOME_ENV_VAR"
  - cat /some/location/in/build
  - cat /some/other/location
```

This is related to work for the CLI: https://github.com/blue-build/cli/issues/434

Code changes for this are incoming, but merging this in ahead of time would allow me to more easily test the new code without validation yelling at me.