### PR TITLE
Add a mounts option to Recipe

### DIFF
--- a/src-tsp/main.tsp
+++ b/src-tsp/main.tsp
@@ -98,6 +98,11 @@ model Recipe {
    * ```
    */
   modules: Array<ModuleEntry>;
+
+  /**
+   * A list of mounts that will be mounted in each RUN stage.
+   */
+  mounts?: Array<Mount>;
 }
 
 enum Platform {
@@ -304,4 +309,56 @@ model ModuleStageList {
    * This is useful for compiling programs from source without polluting the final bootable image.
    */
   stages?: Array<StageEntry>;
+}
+
+@oneOf
+union Mount {
+  MountBind,
+  MountTmpFs,
+  MountCache,
+}
+
+model MountBind {
+  /** A bind mount from the host system. */
+  type: "bind";
+
+  /** The source path on the host system to mount. */
+  source: string;
+
+  /** The destination path to mount to. */
+  destination: string;
+
+  /** Whether the mount should be read-only. */
+  readOnly?: boolean;
+}
+
+model MountTmpFs {
+  /** A temporary file system mount. */
+  type: "tmpfs";
+
+  /** The destination path to mount to. */
+  destination: string;
+
+  /** The size of the tmpfs mount. */
+  size?: string;
+}
+
+enum MountCacheSharing {
+  Shared = "shared",
+  Private = "private",
+  Locked = "locked",
+}
+
+model MountCache {
+  /** A cache mount. */
+  type: "cache";
+
+  /** The destination path to mount to. */
+  destination: string;
+
+  /** An identifier for the cache. */
+  id?: string;
+
+  /** The sharing mode of the cache. */
+  sharing?: MountCacheSharing;
 }


### PR DESCRIPTION
This PR adds a `mounts` option to the model `Recipe`.

This will allow users define their own cache / tmpfs / bind mounts to be appended to each RUN command in the generated Containerfile.

Useful for defining cache mounts for modules to use, for example.