### PR TITLE
feat: add a mounts option to recipe and modules

### DIFF
--- a/src-tsp/main.tsp
+++ b/src-tsp/main.tsp
@@ -338,7 +338,7 @@ model MountBind {
   destination: string;
 
   /** Whether the mount should be read-only. */
-  readOnly?: boolean;
+  readonly?: boolean;
 }
 
 model MountTmpFs {


### PR DESCRIPTION
Continuation of #16.

Changes `readOnly` field to `readonly` for consistency.
Adds `mounts` to ModuleDefaults

---

Original PR message for reference:

This PR adds a `mounts` option to the model `Recipe`.

This will allow users define their own cache / tmpfs / bind mounts to be appended to each RUN command in the generated Containerfile.

Useful for defining cache mounts for modules to use, for example.